### PR TITLE
fix exit code

### DIFF
--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -74,7 +74,7 @@ exports.runner = function(config, configFile) {
       if (output.data) {
         console.log(output.data);
       }
-      done(code);
+      done(null, code);
     });
 
   }, function(err, results) {


### PR DESCRIPTION
This makes triple-latte return correct error codes. (It is currently returning 0 even if tests fail).

Please review @eleith (I seem not to have permissions to triple-latte, so I'm doing this from a forked repo)

mapLimit's done callback takes the result as the second argument and line 87 expects all the codes to be in the results array
