### PR TITLE
Fixing XML ending tags

### DIFF
--- a/lib/xunit.js
+++ b/lib/xunit.js
@@ -41,7 +41,7 @@ function XUnit(runner) {
   runner.on('pass', function(test){
     tests.push(test);
   });
-  
+
   runner.on('fail', function(test){
     tests.push(test);
   });
@@ -56,10 +56,7 @@ function XUnit(runner) {
       skip: stats.tests - stats.failures - stats.passes,
       timestamp: (new global.Date()).toUTCString(),
       time: stats.duration / 1000
-    }, false);
-
-    xml += tests.map(test).join('');
-    xml += tag('testsuite', {}, true);
+    }, false, tests.map(test).join(''));
 
     console.log(xml);
   });
@@ -116,7 +113,7 @@ function tag(name, attrs, close, content) {
   }
 
   _tag = '<' + name + (pairs.length ? ' ' + pairs.join(' ') : '') + end;
-  if (content) _tag += content + '</' + name + end;
+  if (content) _tag += content + '</' + name + '>';
   return _tag;
 }
 


### PR DESCRIPTION
XML tags will never start and end with '</' and '/>'.

Also adjusted the testsuites tag call to use the function call properly
which ends the tag as expected.

Results: 

```
<testsuites>
    <testsuite name="Mocha Tests" tests="7" failures="0" errors="0" skip="0" timestamp="Wed, 12 Nov 2014 02:49:13 GMT" time="2.758">
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="appends review view" time="0.001" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="appends alerts view" time="0" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="appends SubmissionHeader view" time="0" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="has an edit button that links to the edit page" time="0.002" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="submits" time="0.012" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="handles unknown submit errors" time="0.015" />
        <testcase classname="mocha: .Users.jon.base.coursera.site.app.www.static.pages.open-course.test.mocha.peerReview.views.preview: open-course peerReview views preview" name="handles invalid submission errors" time="0.013" />
    </testsuite>
</testsuites>
```
