### PR TITLE
Not all failed things are tests.

### DIFF
--- a/lib/xunit.js
+++ b/lib/xunit.js
@@ -61,15 +61,14 @@ function XUnit(runner, _options) {
     }, tests.map(test).join(''));
 
     if (options.outputDir && tests.length) {
-      // If this test doesn't have a `file` key, it probably failed as a node.js error
-      // or in a hook and will get caught elsewhere
-      if (tests[0].file) {
-        var filename = tests[0].file.replace(/\.js$/, '.xml');
-        if (stats.failures) {
-          files.makeSync(path.join(options.outputDir, 'failed', filename), xml);
-        } else {
-          files.makeSync(path.join(options.outputDir, 'passed', filename), xml);
-        }
+      // The suite always has a filename, let's use that.
+      var filename = tests[0].parent.file
+        .replace(process.cwd(), '')
+        .replace(/\.js$/, '.xml');
+      if (stats.failures) {
+        files.makeSync(path.join(options.outputDir, 'failed', filename), xml);
+      } else {
+        files.makeSync(path.join(options.outputDir, 'passed', filename), xml);
       }
     } else {
       console.log(xml);

--- a/lib/xunit.js
+++ b/lib/xunit.js
@@ -61,11 +61,15 @@ function XUnit(runner, _options) {
     }, tests.map(test).join(''));
 
     if (options.outputDir && tests.length) {
-      var filename = tests[0].file.replace(/\.js$/, '.xml');
-      if (stats.failures) {
-        files.makeSync(path.join(options.outputDir, 'failed', filename), xml);
-      } else {
-        files.makeSync(path.join(options.outputDir, 'passed', filename), xml);
+      // If this test doesn't have a `file` key, it probably failed as a node.js error
+      // or in a hook and will get caught elsewhere
+      if (tests[0].file) {
+        var filename = tests[0].file.replace(/\.js$/, '.xml');
+        if (stats.failures) {
+          files.makeSync(path.join(options.outputDir, 'failed', filename), xml);
+        } else {
+          files.makeSync(path.join(options.outputDir, 'passed', filename), xml);
+        }
       }
     } else {
       console.log(xml);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triple-latte",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "author": {
     "name": "eleith",


### PR DESCRIPTION
The `tests` variable here may be a slight misnomer as it doesn't always represent an actual test (something specified by `it`) - failures in things like [hooks](https://github.com/mochajs/mocha/blob/master/lib/hook.js) get captured here too, and hooks are not tests.

Instead of depending on the thing failing being a test, let's just use the `test.parent` reference, which refers to the "suite" of tests being run, which (hopefully) should always have a `file` property on it. We're also replacing the front part of this file path to replicate the substitution being made [here](https://github.com/coursera/triple-latte/blob/2a965a631ef89e32ada4afacf992012babb70abe/lib/mocha.js#L20)

@eleith PTAL