### PR TITLE
Correctly capturing and reporting Node errors.

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -23,6 +23,51 @@ var overrideBddIt = function(context, file, mocha) {
   context.it.only = oldIt.only;
 };
 
+function setupMocha(mochaOptions, mochaExports) {
+  var mocha = new Mocha(mochaOptions);
+
+  //// need to provide some variables to internal tests
+  mocha.suite.on('pre-require', function(context, file, mocha) {
+    _.each(_.isObject(mochaExports) ? mochaExports : {}, function(req, key) {
+      context[key] = req;
+    });
+
+    overrideBddIt(context, file, mocha);
+  });
+
+  return mocha;
+}
+
+function runMocha(mocha) {
+  try {
+    var runner = mocha.run(function(failures) {
+      if (process && process.send) {
+        process.send({status:'end', file:testFile});
+      }
+      process.exit(failures);
+    });
+
+    runner.on('fail', function(test, err){
+      if (process && process.send) {
+        process.send({status:'fail', file:test.file, title:test.title, message:err.message});
+      }
+    });
+
+    runner.on('pass', function(test){
+      if (process && process.send) {
+        process.send({status:'pass', file:test.file, title:test.title});
+      }
+    });
+  } catch (err) {
+    var filename = mocha.files.length > 1 ? 'Multiple tests failed' : mocha.files[0];
+    // When we have node.js errors, we need to report them differently.
+    if (process && process.send) {
+      process.send({status: 'error', file: filename, message: err.message, stack: err.stack});
+      process.send({status: 'end'});
+    }
+  }
+}
+
 exports.runner = function(config, configFile) {
 
   var reporter = config.reporter || 'spec';
@@ -49,75 +94,23 @@ exports.runner = function(config, configFile) {
   };
 
   if (config.unify) {
-    var mocha = new Mocha(mochaOptions);
-
-    //// need to provide some variables to internal tests
-    mocha.suite.on('pre-require', function(context, file, mocha) {
-      _.each(_.isObject(mochaExports) ? mochaExports : {}, function(req, key) {
-        context[key] = req;
-      });
-
-      overrideBddIt(context, file, mocha);
-    });
+    var mocha = setupMocha(mochaOptions, mochaExports);
 
     files.findTests(testFiles).map(function(testFile) {
       mocha.addFile(testFile);
     });
 
-    var runner = mocha.run(function(failures) {
-      if (process && process.send) {
-        process.send({status:'end', file:testFile});
-      }
-      process.exit(failures);
-    });
-
-    runner.on('fail', function(test, err){
-      if (process && process.send) {
-        process.send({status:'fail', file:test.file, title:test.title, message:err.message});
-      }
-    });
-
-    runner.on('pass', function(test){
-      if (process && process.send) {
-        process.send({status:'pass', file:test.file, title:test.title});
-      }
-    });
+    runMocha(mocha);
   } else {
     var runners = [];
 
     files.findTests(testFiles).map(function(testFile) {
       runners.push(function(done) {
-        var mocha = new Mocha(mochaOptions);
-
-        //// need to provide some variables to internal tests
-        mocha.suite.on('pre-require', function(context, file, mocha) {
-          _.each(_.isObject(mochaExports) ? mochaExports : {}, function(req, key) {
-            context[key] = req;
-          });
-
-          overrideBddIt(context, file, mocha);
-        });
+        var mocha = setupMocha(mochaOptions, mochaExports);
 
         mocha.addFile(testFile);
 
-        var runner = mocha.run(function(failures) {
-          if (process && process.send) {
-            process.send({status:'end', file:testFile});
-          }
-          done(null, failures);
-        });
-
-        runner.on('fail', function(test, err) {
-          if (process && process.send) {
-            process.send({status:'fail', file:testFile, title:test.title, message:err.message});
-          }
-        });
-
-        runner.on('pass', function(test) {
-          if (process && process.send) {
-            process.send({status:'pass', file:testFile, title:test.title});
-          }
-        });
+        runMocha(mocha);
       });
     });
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -38,11 +38,11 @@ function setupMocha(mochaOptions, mochaExports) {
   return mocha;
 }
 
-function runMocha(mocha) {
+function runMocha(mocha, testFile) {
   try {
     var runner = mocha.run(function(failures) {
       if (process && process.send) {
-        process.send({status:'end', file:testFile});
+        process.send({status:'end', file: testFile});
       }
       process.exit(failures);
     });
@@ -100,7 +100,7 @@ exports.runner = function(config, configFile) {
       mocha.addFile(testFile);
     });
 
-    runMocha(mocha);
+    runMocha(mocha, testFiles[0]);
   } else {
     var runners = [];
 
@@ -110,7 +110,7 @@ exports.runner = function(config, configFile) {
 
         mocha.addFile(testFile);
 
-        runMocha(mocha);
+        runMocha(mocha, testFile);
       });
     });
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -62,9 +62,11 @@ function runMocha(mocha, testFile) {
     var filename = mocha.files.length > 1 ? 'Multiple tests failed' : mocha.files[0];
     // When we have node.js errors, we need to report them differently.
     if (process && process.send) {
+      console.log(err.stack);
       process.send({status: 'error', file: filename, message: err.message, stack: err.stack});
       process.send({status: 'end'});
     }
+    process.exit();
   }
 }
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -38,13 +38,18 @@ function setupMocha(mochaOptions, mochaExports) {
   return mocha;
 }
 
-function runMocha(mocha, testFile) {
+function runMocha(mocha, testFile, done) {
   try {
     var runner = mocha.run(function(failures) {
       if (process && process.send) {
         process.send({status:'end', file: testFile});
       }
-      process.exit(failures);
+
+      if (done) {
+        done(null, failures);
+      } else {
+        process.exit(failures);
+      }
     });
 
     runner.on('fail', function(test, err){
@@ -64,7 +69,7 @@ function runMocha(mocha, testFile) {
     if (process && process.send) {
       console.log(err.stack);
       process.send({status: 'error', file: filename, message: err.message, stack: err.stack});
-      process.send({status: 'end'});
+      process.send({status: 'end', file: testFile});
     }
     process.exit();
   }
@@ -112,7 +117,7 @@ exports.runner = function(config, configFile) {
 
         mocha.addFile(testFile);
 
-        runMocha(mocha, testFile);
+        runMocha(mocha, testFile, done);
       });
     });
 

--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -118,6 +118,16 @@ exports.runner = function(config, configFile) {
         totals.failed.push(test);
       } else if (test && test.status === 'pass') {
         totals.passed.push(test);
+      } else if (test && test.status === 'error') {
+        // We want to treat this as a failure, but want to track how many errors we get
+        test.state = 'failed';
+        test.err = {
+          message: test.message,
+          stack: test.stack
+        };
+        test.title = test.file;
+        test.duration = 0;
+        totals.errored.push(test);
       } else if (test.status == 'end') {
         finished = _(finished).difference(test.file);
       }
@@ -125,38 +135,32 @@ exports.runner = function(config, configFile) {
 
     // only write on exit, to prevent coupling of other tests
     oneTestSpawn.on('exit', function(code) {
-      if (code !== 0 && finished.length != 0) {
-        finished.forEach(function(finishedTest) {
-          totals.errored.push({
-            title:'nodejs error outside of test has occurred',
-            file: finishedTest
-          });
-        });
-      }
       done(null, code);
     });
 
   }, function(err, results) {
     if (/xunit.js$/.test(reporter)) {
-      if (!outputDir) {
-        _(totals.errored).each(function(error) {
-          console.log('<testsuite name="Mocha Tests" tests="1" failures="1">');
-          console.log('<failure classname="' + error.file + '" message="nodejs error found" />');
-          console.log('</testsuite>');
-        });
-        // close xunit test with plural tag
-        console.log('</testsuites>');
-      } else {
-        if(totals.errored) {
-          _(totals.errored).each(function(error) {
-            var xml = '<testsuite name="Mocha Tests" tests="1" failures="1">' +
-              '<failure classname="' + error.file + '" message="nodejs error found" />' +
-              '</testsuite>';
-            files.makeSync(path.join(outputDir, 'failed', error.file.replace(/\.js$/, '.xml')), xml);
+      var xunit = require('./xunit');
+
+      totals.errored.forEach(function(test) {
+        var tags = [
+          '<testsuite name="Mocha Tests" tests="1" failures="1">',
+          xunit.prototype.test(test),
+          '</testsuite>'
+        ];
+
+        if (outputDir) {
+          var xml = tags.join('');
+          files.makeSync(path.join(outputDir, 'failed', test.file.replace(/\.js$/, '.xml')), xml);
+          outputResults(totals);
+        } else {
+          // close xunit test with plural tag
+          tags.forEach(function(tag) {
+            console.log(tag);
           });
+          console.log('</testsuites>');
         }
-        outputResults(totals);
-      }
+      });
     } else {
       outputResults(totals);
       writeResults(totals);

--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -141,7 +141,7 @@ exports.runner = function(config, configFile) {
       if (!outputDir) {
         _(totals.errored).each(function(error) {
           console.log('<testsuite name="Mocha Tests" tests="1" failures="1">');
-          console.log('<testcase classname="' + error.file + '" message="nodejs error found" />');
+          console.log('<failure classname="' + error.file + '" message="nodejs error found" />');
           console.log('</testsuite>');
         });
         // close xunit test with plural tag
@@ -150,7 +150,7 @@ exports.runner = function(config, configFile) {
         if(totals.errored) {
           _(totals.errored).each(function(error) {
             var xml = '<testsuite name="Mocha Tests" tests="1" failures="1">' +
-              '<testcase classname="' + error.file + '" message="nodejs error found" />' +
+              '<failure classname="' + error.file + '" message="nodejs error found" />' +
               '</testsuite>';
             files.makeSync(path.join(outputDir, 'failed', error.file.replace(/\.js$/, '.xml')), xml);
           });

--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -140,7 +140,7 @@ exports.runner = function(config, configFile) {
     if (/xunit.js$/.test(reporter)) {
       if (!outputDir) {
         _(totals.errored).each(function(error) {
-          console.log('<testsuite name="Mocha Tests" tests="1" errors="1">');
+          console.log('<testsuite name="Mocha Tests" tests="1" failures="1">');
           console.log('<testcase classname="' + error.file + '" message="nodejs error found" />');
           console.log('</testsuite>');
         });
@@ -149,7 +149,7 @@ exports.runner = function(config, configFile) {
       } else {
         if(totals.errored) {
           _(totals.errored).each(function(error) {
-            var xml = '<testsuite name="Mocha Tests" tests="1" errors="1">' +
+            var xml = '<testsuite name="Mocha Tests" tests="1" failures="1">' +
               '<testcase classname="' + error.file + '" message="nodejs error found" />' +
               '</testsuite>';
             files.makeSync(path.join(outputDir, 'failed', error.file.replace(/\.js$/, '.xml')), xml);

--- a/lib/xunit.js
+++ b/lib/xunit.js
@@ -81,6 +81,7 @@ function XUnit(runner, _options) {
  */
 
 XUnit.prototype.__proto__ = Base.prototype;
+XUnit.prototype.test = test;
 
 /**
  * Output tag for the given `test.`
@@ -95,7 +96,7 @@ function test(_test) {
   }
 
   var attrs = {
-    classname: namespace + ': ' + _test.parent.fullTitle(),
+    classname: namespace + ': ' + (_test.parent && _test.parent.fullTitle()),
     name: _test.title,
     time: _test.duration / 1000
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triple-latte",
-  "version": "0.2.15",
+  "version": "0.3.0",
   "private": true,
   "author": {
     "name": "eleith",


### PR DESCRIPTION
Errors that occur outside of the test harness (most specifically, due to Node errors like misconfigured `require` statements) would sometimes falsely marked tests as "failed" based on the distribution of test files to various worker processes.

Additionally, because Jenkins does not mark builds as unstable or failed based on aforementioned Node errors, I'm capturing all Node errors and reporting them as test failures corresponding to the file they originated from. 

There's a lot of repeated code in the files I touched, I refactored them as best I could to make sure we weren't repeating logic everywhere.

---

Why is it important to report these errors instead of just letting them bubble up and kill the process (and subsequently causing a build failure)? I think there's some value in having the test runners run through all the tests and make sure we can capture all possible failures in one run, instead of having one test obscure the results of the others.