### PR TITLE
Removing test file overrides, specifying file names for failed hooks

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -4,25 +4,6 @@ var files = require('./files');
 var async = require('async');
 var path = require('path');
 
-/**
- * Override some of bdd's post-require definitions in order to save file name in the test
- * for xunit to output.
- */
-var overrideBddIt = function(context, file, mocha) {
-  /**
-   * Describe a specification or test-case
-   * with the given `title` and callback `fn`
-   */
-
-  var oldIt = context.it;
-  context.it = context.specify = function(title, fn){
-    var test = oldIt(title, fn);
-    test.file = file.replace(process.cwd(), '');
-    return test;
-  };
-  context.it.only = oldIt.only;
-};
-
 function setupMocha(mochaOptions, mochaExports) {
   var mocha = new Mocha(mochaOptions);
 
@@ -31,8 +12,6 @@ function setupMocha(mochaOptions, mochaExports) {
     _.each(_.isObject(mochaExports) ? mochaExports : {}, function(req, key) {
       context[key] = req;
     });
-
-    overrideBddIt(context, file, mocha);
   });
 
   return mocha;
@@ -54,7 +33,11 @@ function runMocha(mocha, testFile, done) {
 
     runner.on('fail', function(test, err){
       if (process && process.send) {
-        process.send({status:'fail', file:test.file, title:test.title, message:err.message});
+        process.send({
+          status: 'fail',
+          file: test.file || test.parent && test.parent.file,
+          title:test.title, message:err.message
+        });
       }
     });
 

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -36,7 +36,7 @@ function runMocha(mocha, testFile, done) {
         process.send({
           status: 'fail',
           file: test.file || test.parent && test.parent.file,
-          title:test.title,
+          title: test.title,
           message: err.message
         });
       }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -36,7 +36,8 @@ function runMocha(mocha, testFile, done) {
         process.send({
           status: 'fail',
           file: test.file || test.parent && test.parent.file,
-          title:test.title, message:err.message
+          title:test.title,
+          message: err.message
         });
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triple-latte",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "author": {
     "name": "eleith",


### PR DESCRIPTION
When tests failed within hooks (like beforeEach or afterEach), triple-latte would report "undefined" as the source, making it really difficult to track down errors. This will use the file from the test, and the file from the suite if we're inside a hook.

File information is already on the test object as of https://github.com/mochajs/mocha/issues/950

Same with the test suites: https://github.com/mochajs/mocha/commit/55f01bcb3713cc26294d07b610bd079c232f4404

@eleith PTAL