### PR TITLE
No summary output mode

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,7 +27,7 @@ var defaults = {
   timeout: parseInt(program.timeout),
   unify: program.unify,
   outputDir: program.outputDir,
-  noSummary: program.nosummary
+  noSummary: program.nosummary || false,
 };
 
 var options = _.extend(defaults, config);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,7 @@ program.version('0.2.0')
   .option('-t, --timeout [time_in_ms]', 'timeout that will kill each test', 2000)
   .option('-c, --config [file]', 'configuration file for specifying tests and globals')
   .option('-o, --outputDir [dir]', 'output tests results as files in the output directory, only works with xunit reporter')
+  .option('-x, --nosummary', 'do not output the test file summary at the end of a test run')
   .parse(process.argv);
 
 var config = program.config ? require(path.resolve(program.config)) : {};
@@ -26,6 +27,7 @@ var defaults = {
   timeout: parseInt(program.timeout),
   unify: program.unify,
   outputDir: program.outputDir,
+  noSummary: program.nosummary
 };
 
 var options = _.extend(defaults, config);

--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -76,6 +76,7 @@ exports.runner = function(config, configFile) {
   var mochaExports = config.exports || {};
   var workers = config.workers;
   var split = config.split;
+  var noSummary = config.noSummary;
   var ui = config.ui || 'bdd';
   var testFiles = config.tests ? config.tests : ['./tests', './test'];
   var totals = {passed:[], failed:[], errored:[], pending: [], slow: []};
@@ -189,7 +190,10 @@ exports.runner = function(config, configFile) {
         }
       });
     } else {
-      outputResults(totals);
+      if (noSummary) {
+        console.log('No summary');
+        outputResults(totals);
+      }
       writeResults(totals);
     }
 

--- a/lib/multiMocha.js
+++ b/lib/multiMocha.js
@@ -190,8 +190,7 @@ exports.runner = function(config, configFile) {
         }
       });
     } else {
-      if (noSummary) {
-        console.log('No summary');
+      if (!noSummary) {
         outputResults(totals);
       }
       writeResults(totals);


### PR DESCRIPTION
Not sure if this is the right way to go about it, let me know, but there are cases when i don't want to display an overall summary again.

When just running single tests, I don't need to see the overall summary since the overall summary for 1 test run is the same...

This helps me go from:

![image](https://cloud.githubusercontent.com/assets/588210/14807478/c03507f2-0b31-11e6-88d7-5c2bea1f37c4.png)

to

![image](https://cloud.githubusercontent.com/assets/588210/14807485/c89a4a10-0b31-11e6-85ef-b4d52b69d598.png)