### PR TITLE
Allow passing in test file paths through a temp file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,7 +16,7 @@ program.version('0.2.0')
   .option('-c, --config [file]', 'configuration file for specifying tests and globals')
   .option('-o, --outputDir [dir]', 'output tests results as files in the output directory, only works with xunit reporter')
   .option('-x, --nosummary', 'do not output the test file summary at the end of a test run')
-  .option('-z, --tmpfilelist [path]', 'a file that has a test file per line. used to get passed the argument list limit.')
+  .option('-z, --tmpfilelist [path]', 'a file that has a test file per line. used to get past the argument list limit.')
   .parse(process.argv);
 
 var config = program.config ? require(path.resolve(program.config)) : {};
@@ -35,12 +35,12 @@ var defaults = {
 
 var options = _.extend(defaults, config);
 
-var filesFromTmpFileList;
+var filesFromTmpFileList = [];
 if (program.tmpfilelist) {
   filesFromTmpFileList = fs.readFileSync(program.tmpfilelist, 'utf8').split('\n');
 }
 
-options.tests = program.args.length ? program.args : (filesFromTmpFileList || []).concat(config.test || []);
+options.tests = program.args.length ? program.args : filesFromTmpFileList.concat(config.test || []);
 
 // if zero workers are specified, then we are likely spawning
 // and want to run individual tests.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@ var program = require('commander');
 var mocha = require('./mocha');
 var multiMocha = require('./multiMocha');
 var path = require('path');
+var fs = require('fs');
 var _ = require('underscore');
 
 program.version('0.2.0')
@@ -15,6 +16,7 @@ program.version('0.2.0')
   .option('-c, --config [file]', 'configuration file for specifying tests and globals')
   .option('-o, --outputDir [dir]', 'output tests results as files in the output directory, only works with xunit reporter')
   .option('-x, --nosummary', 'do not output the test file summary at the end of a test run')
+  .option('-z, --tmpfilelist [path]', 'a file that has a test file per line. used to get passed the argument list limit.')
   .parse(process.argv);
 
 var config = program.config ? require(path.resolve(program.config)) : {};
@@ -30,8 +32,15 @@ var defaults = {
   noSummary: program.nosummary || false,
 };
 
+
 var options = _.extend(defaults, config);
-options.tests = program.args.length ? program.args : config.tests || ['./tests', './test'];
+
+var filesFromTmpFileList;
+if (program.tmpfilelist) {
+  filesFromTmpFileList = fs.readFileSync(program.tmpfilelist, 'utf8').split('\n');
+}
+
+options.tests = program.args.length ? program.args : (filesFromTmpFileList || []).concat(config.test || []);
 
 // if zero workers are specified, then we are likely spawning
 // and want to run individual tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triple-latte",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "author": {
     "name": "eleith",


### PR DESCRIPTION
There is a argument list length limit that is dependent on the UNIX kernel limit.

We've reached that limit so we can no longer pass raw file paths as an argument list. The reason why we did this in the first place over computing it in `test/config` was that every fork would evaluate the glob pattern in `test/config` which would spin the CPU (and lead to slow startup).

This diff enables triple latte to accept a list of files delimited by `\n`, which effectively circumvents the argument list length limit and goes with https://phabricator.dkandu.me/D38002
