### PR TITLE
Update triple-latte package versions to recent as of October 2016

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
     "test"
   ],
   "dependencies": {
-    "async": "0.8.0",
-    "cli-color": "0.3.2",
-    "commander": "1.1.1",
-    "growl": "1.6.1",
-    "mocha": "2.0.1",
+    "async": "^1.5.0",
+    "cli-color": "^1.1.0",
+    "commander": "2.9.0",
+    "mocha": "^3.1.2",
     "underscore": "1.5.1",
     "wrench": "1.5.8"
   },


### PR DESCRIPTION
cc @jnwng, some of these packages are really old, i run the test suite locally and this seems to work fine.

i'm hoping this catches some of the performance regressions that we experienced with our upgrade to Node 6
